### PR TITLE
Fix module name in README and go.mod to match the correct repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ## Setup
 ### Install with go get
 ```bash
-go get github.com/deady54/mapepire-go
+go get github.com/Mapepire-IBMi/mapepire-go
 ```
 ### Server Component Setup
 To use mapepire-go, you will need to have the Mapepire Server Component running on your IBM i server. Follow these instructions to set up the server component: [Mapepire Server Installation](https://mapepire-ibmi.github.io/guides/sysadmin/)
@@ -18,7 +18,7 @@ package main
 import (
 	"log"
 
-	mapepire "github.com/deady54/mapepire-go"
+	mapepire "github.com/Mapepire-IBMi/mapepire-go"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/deady54/mapepire-go
+module github.com/Mapepire-IBMi/mapepire-go
 
 go 1.21.0
 


### PR DESCRIPTION
Fix module name in README and go.mod to match the correct repository.
go get doesnt like not matching repo- and module-name.