### PR TITLE
Add table field to column struct

### DIFF
--- a/types.go
+++ b/types.go
@@ -49,8 +49,15 @@ type metadata struct {
 
 // Represents the columns of the DB
 type column struct {
-	Name        string
-	Type        string
-	Label       string
-	DisplaySize int `json:"display_size"`
+	Name          string
+	Type          string
+	Label         string
+	DisplaySize   int `json:"display_size"`
+	Precision     int
+	Scale         int
+	AutoIncrement bool
+	Nullable      int
+	ReadOnly      bool
+	Writeable     bool
+	Table         string
 }


### PR DESCRIPTION
To be merged after https://github.com/Mapepire-IBMi/mapepire-server/pull/131

Adds the `table` field added in https://github.com/Mapepire-IBMi/mapepire-server/pull/131 to the column metadata. Also adds other missing fields from the column metadata.