### PR TITLE
Reconnect pool jobs after Server restart

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -67,6 +67,7 @@ func (jp *JobPool) GetJob() (s *SQLJob, err error) {
 		if s.connection == nil {
 			err := s.Connect(jp.options.Creds)
 			if err != nil {
+				jp.AddJob(s)
 				return nil, err
 			}
 		}
@@ -99,6 +100,9 @@ func (jp *JobPool) AddJob(s *SQLJob) error {
 	}
 	if len(jp.jobPool) >= jp.options.MaxSize {
 		return fmt.Errorf("not enough space in the pool")
+	}
+	if s.Status == JOBSTATUS_ERROR {
+		s.connection = nil
 	}
 	jp.jobPool <- s
 	return nil

--- a/sqlJob.go
+++ b/sqlJob.go
@@ -127,18 +127,21 @@ func (s *SQLJob) send(req serverRequest) (*ServerResponse, error) {
 	s.writeMutex.Lock()
 	defer s.writeMutex.Unlock()
 	if err := s.connection.WriteMessage(1, []byte(req.jsonreq)); err != nil {
+		s.setJobStatus(JOBSTATUS_ERROR)
 		msg := "WriteMessage(): " + err.Error()
 		return response, &WebsocketError{Method: "send()", Message: msg}
 	}
 
 	_, resp, err := s.connection.ReadMessage()
 	if err != nil {
+		s.setJobStatus(JOBSTATUS_ERROR)
 		msg := "ReadMessage(): " + err.Error()
 		return response, &WebsocketError{Method: "send()", Message: msg}
 	}
 
 	response.SqlRC, response.SqlState, response.Error = checkJsonErr(resp, s)
 	if response.Error != nil {
+		s.setJobStatus(JOBSTATUS_ERROR)
 		return response, response.Error
 	}
 


### PR DESCRIPTION
Problem:
1. Add job back to pool if Connect() fails
-> if all jobs fail to connect, there are no more -> ERROR: "exceeded time limit" on each request

2. Using the following syntax, while restarting mapepire server:
```go
job, _ := pool.GetJob()
defer pool.AddJob(job)
query, _ := job.QueryWithOptions()
response, _ := query.Execute()
```
-> the connection was not set to nil after a WebsocketError (as in pool.ExecuteSQLWithOptions())
-> this led to "write errors on broken pipe" on each request
-> set the job status to ERROR, check in AddJob() if the connection needs to be reset. 
 
Pooljobs will now reconnect on server restart. 